### PR TITLE
Fix bugs in graphs

### DIFF
--- a/auxdata/graphs/add_elevation.xml
+++ b/auxdata/graphs/add_elevation.xml
@@ -28,7 +28,7 @@
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
       <sourceBands>elevation</sourceBands>
       <region/>
-      <referenceBand>B2</referenceBand>
+      <referenceBand/>
       <geoRegion/>
       <subSamplingX>1</subSamplingX>
       <subSamplingY>1</subSamplingY>

--- a/auxdata/graphs/add_landcover.xml
+++ b/auxdata/graphs/add_landcover.xml
@@ -24,7 +24,7 @@
       <sourceProduct refid="AddLandCover"/>
     </sources>
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
-      <sourceBands>CCILandCover-2015</sourceBands>
+      <sourceBands/>
       <region/>
       <referenceBand/>
       <geoRegion/>


### PR DESCRIPTION
All the current graphs used in the plugin presents some issues. I have already solved all of them but I want to agree with you before proposing. The solved graphs are in this [repository](https://github.com/LorenzoStucchi/SEN-ET_automatization/tree/master/graph).

I list here the issue:
- [ ] `add_elevation.xml` wrong reference to the band that could create issue, solved in https://github.com/DHI-GRAS/sen-et-snap-scripts/commit/729d7b2e7cd410dd926fcf15c118402013304f40
- [ ] `add_landcover.xml` wrong reference in the band that could create issue, solved in https://github.com/DHI-GRAS/sen-et-snap-scripts/commit/bb614d564c564c811d56981f429b21314a89b854
- [ ] `sentinel_3_pre_processing.xml` few missing band and wrong input nome but works, a correction could be the one proposed [here](https://github.com/LorenzoStucchi/SEN-ET_automatization/blob/master/graph/sentinel_3_pre_processing_fix.xml), also it is suggested to cut the images on the area of interest to speedup the process
- [ ] `sentinel_2_pre_processing.xml` the actual graph is not working due to an error of SNAP `Error: org.esa.snap.core.gpf.graph.GraphException`. The solution used is to split the graph is four different ones that are:

     1. [`BandMaths_mask_sentinel_2_pre_processing.xml`](https://github.com/LorenzoStucchi/SEN-ET_automatization/blob/master/graph/BandMaths_mask_sentinel_2_pre_processing.xml)
     2. [`BiophysicalOp_sentinel_2_pre_processing.xml`](https://github.com/LorenzoStucchi/SEN-ET_automatization/blob/master/graph/BiophysicalOp_sentinel_2_pre_processing.xml)
     3. [`reflectance_sentinel_2_pre_processing.xml`](https://github.com/LorenzoStucchi/SEN-ET_automatization/blob/master/graph/reflectance_sentinel_2_pre_processing.xml)
     4. [`sun_zenith_sentinel_2_pre_processing.xml`](https://github.com/LorenzoStucchi/SEN-ET_automatization/blob/master/graph/sun_zenith_sentinel_2_pre_processing.xml)