### PR TITLE
Fix in the script `ecmwf_data_download.py` save output as file

### DIFF
--- a/ecmwf_data_download.py
+++ b/ecmwf_data_download.py
@@ -8,7 +8,7 @@ from ecmwf_utils import download_CDS_data
 @click.option('--area', required=False)
 @click.option('--start_date', required=True)
 @click.option('--end_date', required=True)
-@click.option('--download_path', required=True, type=click.Path(file_okay=False))
+@click.option('--download_path', required=True, type=click.Path(dir_okay=False))
 @click.option('--download_temperature', required=True, type=click.BOOL)
 @click.option('--download_dewpoint', required=True, type=click.BOOL)
 @click.option('--download_pressure', required=True, type=click.BOOL)


### PR DESCRIPTION
The ouput of the cdsapi request is requested to be a file and not a path.

As shown in the [example](https://cds.climate.copernicus.eu/api-how-to#use-the-cds-api-client-for-data-access):
```
c.retrieve("dataset-short-name", 
           {... sub-selection request ...}, 
           "target-file")
```